### PR TITLE
Define `FCONE` as needed for <= R 3.6.2

### DIFF
--- a/src/blas.h
+++ b/src/blas.h
@@ -1,0 +1,17 @@
+#ifndef KERNLAB_BLAS_H
+#define KERNLAB_BLAS_H
+
+// For forward compatibility with >= R 4.2.0
+#ifndef USE_FC_LEN_T
+# define USE_FC_LEN_T
+#endif
+
+#include <R_ext/BLAS.h>
+
+// For backwards compatibility with <= R 3.6.2
+// where `FCONE` wasn't defined by R yet
+#ifndef FCONE
+# define FCONE
+#endif
+
+#endif

--- a/src/dcauchy.c
+++ b/src/dcauchy.c
@@ -1,8 +1,5 @@
 #include <stdlib.h>
-#ifndef USE_FC_LEN_T
-# define USE_FC_LEN_T
-#endif
-#include <R_ext/BLAS.h>
+#include "blas.h"
 
 extern void *xmalloc(size_t);
 /* LEVEL 1 BLAS */

--- a/src/dprecond.c
+++ b/src/dprecond.c
@@ -1,10 +1,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#ifndef USE_FC_LEN_T
-# define USE_FC_LEN_T
-#endif
-#include <R_ext/Lapack.h>
+#include "lapack.h"
 /* LAPACK */
 /* extern int dpotf2_(char *, int *, double *, int *, int *); */
 

--- a/src/dprsrch.c
+++ b/src/dprsrch.c
@@ -1,9 +1,6 @@
 #include <stdlib.h>
 #include <string.h>
-#ifndef USE_FC_LEN_T
-# define USE_FC_LEN_T
-#endif
-#include <R_ext/BLAS.h>
+#include "blas.h"
 extern double mymin(double, double);
 extern double mymax(double, double);
 extern void *xmalloc(size_t);

--- a/src/dspcg.c
+++ b/src/dspcg.c
@@ -1,8 +1,5 @@
 #include <stdlib.h>
-#ifndef USE_FC_LEN_T
-# define USE_FC_LEN_T
-#endif
-#include <R_ext/BLAS.h>
+#include "blas.h"
 extern void *xmalloc(size_t);
 extern double mymin(double, double);
 extern double mymax(double, double);

--- a/src/dtron.c
+++ b/src/dtron.c
@@ -2,10 +2,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#ifndef USE_FC_LEN_T
-# define USE_FC_LEN_T
-#endif
-#include <R_ext/BLAS.h>
+#include "blas.h"
 
 extern void *xmalloc(size_t);
 extern double mymin(double, double);

--- a/src/dtrpcg.c
+++ b/src/dtrpcg.c
@@ -1,10 +1,7 @@
 #include <stdlib.h>
 #include <math.h>
 #include <string.h>
-#ifndef USE_FC_LEN_T
-# define USE_FC_LEN_T
-#endif
-#include <R_ext/BLAS.h>
+#include "blas.h"
 
 extern void *xmalloc(size_t);
 /* LEVEL 1 BLAS */

--- a/src/lapack.h
+++ b/src/lapack.h
@@ -1,0 +1,17 @@
+#ifndef KERNLAB_LAPACK_H
+#define KERNLAB_LAPACK_H
+
+// For forward compatibility with >= R 4.2.0
+#ifndef USE_FC_LEN_T
+# define USE_FC_LEN_T
+#endif
+
+#include <R_ext/Lapack.h>
+
+// For backwards compatibility with <= R 3.6.2
+// where `FCONE` wasn't defined by R yet
+#ifndef FCONE
+# define FCONE
+#endif
+
+#endif

--- a/src/solvebqp.c
+++ b/src/solvebqp.c
@@ -1,9 +1,6 @@
 #include <stdlib.h>
 #include <string.h>
-#ifndef USE_FC_LEN_T
-# define USE_FC_LEN_T
-#endif
-#include <R_ext/BLAS.h>
+#include "blas.h"
 /* LEVEL 1 BLAS */
 /*extern double ddot_(int *, double *, int *, double *, int *); */
 /* LEVEL 2 BLAS */


### PR DESCRIPTION
The main idea is to define `FCONE` after including `R_ext/BLAS.h`. This typically defines `FCONE` for us, except on <= R 3.6.2, where the code for that wasn't in R yet.

We use a similar idea for `R_ext/Lapack.h`. It includes `R_ext/BLAS.h`, so we also need to check for `FCONE` after including it.